### PR TITLE
Upgrade Werkzeug to 0.15.5 to fix #23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ pytz==2017.3
 selenium==3.8.1
 six==1.11.0
 SQLAlchemy>=1.3.0
-Werkzeug==0.15.3
+Werkzeug==0.15.5


### PR DESCRIPTION
As mentioned in #23, there's a bug in Werkzeug that throws the following error when trying to create the sqlite database `TypeError: required field "type_ignores" missing from Module`

Upgrading it to 0.15.5 fixes the problem.