### PR TITLE
upgrade flask-sqlalchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ Flask-Cors==3.0.3
 Flask-Migrate==2.1.1
 flask-restx==0.2.0
 Flask-Script==2.0.6
-Flask-SQLAlchemy==2.3.2
+Flask-SQLAlchemy==2.5.1
 Flask-Testing==0.7.1
 gunicorn==19.7.1
 itsdangerous==0.24


### PR DESCRIPTION
We need to upgrade the flask-sqlalchemy version to =>2.5, else the tests throws error. The problem here is that, Flask-SQLAlchemy is not able to connect to sqllite db. [ Similar to this one](https://stackoverflow.com/questions/66647787/attributeerror-cant-set-attribute-when-connecting-to-sqlite-database-with-flas)

The solution to this is upgrading the version as mentioned in this [github issue](https://github.com/pallets/flask-sqlalchemy/issues/910#issuecomment-802098285)